### PR TITLE
fix(cdk): fix access issue for codebuild to create log stream

### DIFF
--- a/lib/aws/hs_sdk.ts
+++ b/lib/aws/hs_sdk.ts
@@ -75,6 +75,13 @@ export class HyperswitchSDKStack {
       })
     );
 
+    project.addToRolePolicy(
+      new PolicyStatement({
+        actions: ["logs:CreateLogStream"],
+        resources: ["*"],
+      })
+    );
+
     // Allow the CodeBuild project to access the S3 bucket
     bucket.grantReadWrite(project);
 


### PR DESCRIPTION
To fix below error

```
ACCESS_DENIED: Service role arn:aws:iam::635860166408:role/hyperswitch-HyperswitchSDKRole1582BB5D-sG84LE5TvYqn does not allow AWS CodeBuild to create Amazon CloudWatch Logs log streams for build arn:aws:codebuild:us-east-2:635860166408:build/HyperswitchSDK:11c70fed-c53b-4468-856b-90ae2b7d0689. Error message: User: arn:aws:sts::635860166408:assumed-role/hyperswitch-HyperswitchSDKRole1582BB5D-sG84LE5TvYqn/AWSCodeBuild-11c70fed-c53b-4468-856b-90ae2b7d0689 is not authorized to perform: logs:CreateLogStream on resource: arn:aws:logs:us-east-2:635860166408:log-group:/aws/codebuild/HyperswitchSDK:log-stream:11c70fed-c53b-4468-856b-90ae2b7d0689 because no identity-based policy allows the logs:CreateLogStream action
```