### PR TITLE
refactor(rds): remove public access to rds

### DIFF
--- a/lib/aws/rds.ts
+++ b/lib/aws/rds.ts
@@ -65,7 +65,6 @@ export class DataBaseConstruct {
           rds_config.writer_instance_class,
           rds_config.writer_instance_size
         ),
-        publiclyAccessible: true,
       }),
       readers: [
         ClusterInstance.provisioned("Reader Instance", {
@@ -76,7 +75,7 @@ export class DataBaseConstruct {
         }),
       ],
       vpc,
-      vpcSubnets: { subnetType: SubnetType.PUBLIC },
+      vpcSubnets: { subnetType: SubnetType.PRIVATE_WITH_EGRESS },
       engine,
       port: rds_config.port,
       securityGroups: [db_security_group],
@@ -84,9 +83,6 @@ export class DataBaseConstruct {
       credentials: Credentials.fromSecret(secret),
       removalPolicy: RemovalPolicy.DESTROY,
     });
-
-    // Add ingress rule to allow traffic from any IP address
-    db_cluster.connections.allowFromAnyIpv4(Port.tcp(rds_config.port));
 
     this.db_cluster = db_cluster;
 


### PR DESCRIPTION
This PR has changes to make rds to use PRIVATE subnet instead of a public subnet. It also removes access to any user to database (which is via 0.0.0.0).

I am able to successfully deploy the stack and use database through private subnet from both grafana and application.

<img width="1350" alt="image" src="https://github.com/juspay/hyperswitch-cdk/assets/126162378/25dbe62c-238c-40a3-bf40-ae6956ab3a52">

<img width="905" alt="image" src="https://github.com/juspay/hyperswitch-cdk/assets/126162378/64b2573d-1b3d-45c8-b28e-0867da8d71d6">
