### PR TITLE
refactor(rds): enable rds storage encryption

### DIFF
--- a/lib/aws/rds.ts
+++ b/lib/aws/rds.ts
@@ -78,6 +78,7 @@ export class DataBaseConstruct {
       vpc,
       vpcSubnets: { subnetType: SubnetType.PUBLIC },
       engine,
+      storageEncrypted: true,
       port: rds_config.port,
       securityGroups: [db_security_group],
       defaultDatabaseName: db_name,


### PR DESCRIPTION
This PR contains changes that can enable database storage encryption with a default KMS key managed by AWS. We should discuss about providing an option to user to use his own aws kms key instead of default aws managed key.
I have tested the changes using installation script.
<img width="1133" alt="image" src="https://github.com/juspay/hyperswitch-cdk/assets/126162378/0599e3e5-53e6-4f2e-bec6-d072e84bf270">
