### PR TITLE
chore(tags): add tags for AWS constructs that are being created by CDK

### DIFF
--- a/lib/aws/card-vault/components.ts
+++ b/lib/aws/card-vault/components.ts
@@ -279,6 +279,8 @@ export class LockerSetup extends Construct {
       "locker_db_subnet_id",
     );
 
+    cdk.Tags.of(this).add("SubStack", "Locker");
+
     // Creating Database for LockerData
     const engine = DatabaseClusterEngine.auroraPostgres({
       version: AuroraPostgresEngineVersion.VER_13_7,

--- a/lib/aws/config.ts
+++ b/lib/aws/config.ts
@@ -75,6 +75,10 @@ export type LockerConfig = {
     db_user: string;
 };
 
+export type Tags = {
+  [key: string]: string;
+};
+
 export type Config = {
     stack: StackConfig;
     locker: LockerConfig;
@@ -83,6 +87,7 @@ export type Config = {
     extra_subnets: ExtraSubnetConfig[]; // TODO: remove this if not required
     hyperswitch_ec2: EC2;
     rds: RDSConfig;
+    tags: Tags;
 };
 
 export type ImageBuilderConfig = {

--- a/lib/aws/eks.ts
+++ b/lib/aws/eks.ts
@@ -39,6 +39,8 @@ export class EksStack {
       clusterName: "hs-eks-cluster",
     });
 
+    cdk.Tags.of(cluster).add("SubStack", "HyperswitchEKS");
+
     const addClusterRole = (awsArn: string, name: string) => {
       if (!awsArn) return;
       const isRole = awsArn.includes(":role") || awsArn.includes(":assumed-role");

--- a/lib/aws/stack.ts
+++ b/lib/aws/stack.ts
@@ -23,6 +23,8 @@ export class AWSStack extends cdk.Stack {
     });
 
     cdk.Tags.of(this).add("Stack", "Hyperswitch");
+    cdk.Tags.of(this).add("StackName", config.stack.name);
+
     Object.entries(config.tags).forEach(([key, value]) => {
       cdk.Tags.of(this).add(key, value);
     });


### PR DESCRIPTION
This change adds certain constant tags to the stack, as well as providing functionality to custom add tags to the stack via configuration.

This is implemented with the reference of : https://docs.aws.amazon.com/cdk/v2/guide/tagging.html