### PR TITLE
chore: add function to remove the default VPC

### DIFF
--- a/lib/aws/config.ts
+++ b/lib/aws/config.ts
@@ -34,6 +34,7 @@ export type VpcConfig = {
 export type SubnetConfigs = {
     public: SubnetConfig;
     dmz: SubnetConfig;
+    remove_default: boolean;
 };
 
 export type SubnetConfig = {

--- a/lib/aws/stack.ts
+++ b/lib/aws/stack.ts
@@ -106,6 +106,10 @@ export class AWSStack extends cdk.Stack {
           elasticache.cluster.attrRedisEndpointAddress,
         );
       }
+
+      let _ = new DefaultRemoverStack(this, config);
+
+
       let eks = new EksStack(
         this,
         config,

--- a/lib/aws/subnet.ts
+++ b/lib/aws/subnet.ts
@@ -1,15 +1,33 @@
-import * as ec2 from 'aws-cdk-lib/aws-ec2';
-import { Construct } from 'constructs';
-import { Config } from './config';
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import { Construct } from "constructs";
+import { Config } from "./config";
+import { RemovalPolicy } from "aws-cdk-lib";
 
 export class SubnetStack {
-    constructor(scope: Construct , vpc: ec2.Vpc, config: Config) {
-        config.extra_subnets.forEach((subnetConfig) => {
-            const subnet = new ec2.Subnet(scope, subnetConfig.id, {
-                vpcId: vpc.vpcId,
-                cidrBlock: subnetConfig.cidr,
-                availabilityZone: vpc.availabilityZones[0],
-            });
-        });
+  constructor(scope: Construct, vpc: ec2.Vpc, config: Config) {
+    config.extra_subnets.forEach((subnetConfig) => {
+      const subnet = new ec2.Subnet(scope, subnetConfig.id, {
+        vpcId: vpc.vpcId,
+        cidrBlock: subnetConfig.cidr,
+        availabilityZone: vpc.availabilityZones[0],
+      });
+    });
+  }
+}
+
+export class DefaultRemoverStack extends Construct {
+  constructor(scope: Construct, config: Config) {
+    super(scope, "DefaultRemovalStack");
+
+    /// Early return if the default subnet is not to be removed
+    if (!config.subnet.remove_default) {
+      return;
     }
+
+    const vpc = ec2.Vpc.fromLookup(this, "VPC", {
+      isDefault: true,
+    });
+
+    vpc.applyRemovalPolicy(RemovalPolicy.DESTROY);
+  }
 }


### PR DESCRIPTION
This is a POC to check if it is possible to delete the default VPC and all its child components from CDK. 