### PR TITLE
refactor: restrict public read access to db migration s3 bucket

### DIFF
--- a/lib/aws/rds.ts
+++ b/lib/aws/rds.ts
@@ -85,9 +85,9 @@ export class DataBaseConstruct {
       const schemaBucket = new Bucket(scope, "SchemaBucket", {
         removalPolicy: RemovalPolicy.DESTROY,
         blockPublicAccess: new s3.BlockPublicAccess({
-          blockPublicAcls: false,
+          blockPublicAcls: true,
         }),
-        publicReadAccess: true,
+        publicReadAccess: false,
         autoDeleteObjects: true,
         bucketName:
           "hyperswitch-schema-" +


### PR DESCRIPTION
In free tier deployment mode, we are currently creating public s3 buckets which is not secure. Also, most of the organizational accounts will not have access to create public s3 buckets which might cause failure in the deployment of the stack. This PR eliminates the need to create a publicly accessible s3 bucket for db migrations.