### PR TITLE
fix: check for currect rust binary

### DIFF
--- a/mac_deps.sh
+++ b/mac_deps.sh
@@ -1,43 +1,40 @@
 #! /usr/bin/env bash
 set -uo pipefail
 
-if ! command -v brew &> /dev/null
-then
-    echo "Homebrew could not be found. Installing..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+if ! command -v brew &>/dev/null; then
+	echo "Homebrew could not be found. Installing..."
+	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
-if ! command -v helm &> /dev/null
-then
-    brew install helm
-    brew link helm
+
+if ! command -v helm &>/dev/null; then
+	brew install helm
+	brew link helm
 fi
-if ! command -v jq &> /dev/null
-then
-    brew install jq
-    brew link jq
+
+if ! command -v jq &>/dev/null; then
+	brew install jq
+	brew link jq
 fi
-if ! command -v kubectl &> /dev/null
-then
-    brew install kubectl
+
+if ! command -v kubectl &>/dev/null; then
+	brew install kubectl
 fi
+
 # Check and Install AWS CLI
-if ! command -v aws &> /dev/null
-then
-    curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-    echo "Please enter password. Make sure you have admin permissions\n"
-    sudo installer -pkg AWSCLIV2.pkg -target /
+if ! command -v aws &>/dev/null; then
+	curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+	echo "Please enter password. Make sure you have admin permissions\n"
+	sudo installer -pkg AWSCLIV2.pkg -target /
 fi
 
-if ! command -v node &> /dev/null
-then
-    brew upgrade
-    brew install node
-    node -v
+if ! command -v node &>/dev/null; then
+	brew upgrade
+	brew install node
+	node -v
 fi
 
-if ! command -v rust &> /dev/null
-then
-    brew install rust
-    rustc --version
-    cargo --version
+if ! command -v rustc &>/dev/null; then
+	brew install rust
+	rustc --version
+	cargo --version
 fi


### PR DESCRIPTION
The `mac_deps.sh` was checking for a not existent rust binary. 
It was updated to check the `rustc` binary.