### PR TITLE
fix(version-update): Deployment Fixes for Free-tier Setup

### DIFF
--- a/lib/aws/config.ts
+++ b/lib/aws/config.ts
@@ -1,5 +1,6 @@
 // import * as cdk from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as iam from "aws-cdk-lib/aws-iam";
 import { KeymanagerConfig } from "./keymanager/stack"
 
 export enum Environment {
@@ -67,6 +68,8 @@ export type EC2 = {
     master_enc_key: string;
     redis_host: string;
     db_host: string;
+    app_alb_dns?: string;
+    sdk_alb_dns?: string;
 };
 
 
@@ -108,4 +111,7 @@ export type EC2Config = {
     ssmSessionPermissions?: boolean;
     associatePublicIpAddress?: boolean;
     allowOutboundTraffic?: boolean;
+    role?: iam.IRole;
+    app_alb_dns?: string;
+    sdk_alb_dns?: string;
 }

--- a/lib/aws/rds.ts
+++ b/lib/aws/rds.ts
@@ -150,7 +150,7 @@ def lambda_handler(event, context):
         # Call the upload_file_from_url function to upload two files to S3
         if event['RequestType'] == 'Create':
           upload_file_from_url("https://raw.githubusercontent.com/juspay/hyperswitch-cdk/main/lib/aws/migrations/migration_runner.zip", "hyperswitch-schema-${process.env.CDK_DEFAULT_ACCOUNT}-${process.env.CDK_DEFAULT_REGION}", "migration_runner.zip")
-          upload_file_from_url("https://raw.githubusercontent.com/juspay/hyperswitch-cdk/main/lib/aws/migrations/v1.113.0/schema.sql", "hyperswitch-schema-${process.env.CDK_DEFAULT_ACCOUNT}-${process.env.CDK_DEFAULT_REGION}", "schema.sql")
+          upload_file_from_url("https://raw.githubusercontent.com/juspay/hyperswitch-cdk/main/lib/aws/migrations/v1.107.0/schema.sql", "hyperswitch-schema-${process.env.CDK_DEFAULT_ACCOUNT}-${process.env.CDK_DEFAULT_REGION}", "schema.sql")
           upload_file_from_url("https://raw.githubusercontent.com/juspay/hyperswitch-cdk/main/lib/aws/migrations/locker-schema.sql", "hyperswitch-schema-${process.env.CDK_DEFAULT_ACCOUNT}-${process.env.CDK_DEFAULT_REGION}", "locker-schema.sql")
           send(event, context, SUCCESS, { "message" : "Files uploaded successfully"})
         else:

--- a/lib/aws/sdk_userdata.sh
+++ b/lib/aws/sdk_userdata.sh
@@ -6,20 +6,23 @@ sudo yum install jq -y
 sudo service docker start
 sudo usermod -a -G docker ec2-user
 sudo yum groupinstall -y "Development Tools"
+sudo yum install -y amazon-ssm-agent
+systemctl enable amazon-ssm-agent
+systemctl start amazon-ssm-agent
 export LC_ALL=en_US.UTF-8
 
 # start a simple http server to serve the Hyperswitch SDK
-backend_url={{router_host}}
-hyperswitch_client_url=$(curl ifconfig.me)
+backend_url={{app_cloudfront_url}}
+hyperswitch_client_url=http://{{sdk_cloudfront_url}}
 
 cd /
-# pull the compiled Hyperswitch SDK from the S3 bucket
+# pull the compiled Hyperswitch SDK
 sudo curl https://raw.githubusercontent.com/juspay/hyperswitch-cdk/refs/heads/main/single-click/data.zip --output data.zip
 sudo unzip -o data.zip
 
 # Replace the backend_url and hyperswitch_client_url in the SDK
-sudo find /data -type f -name "*.js" -exec sed -i "s/backend_url/$backend_url/g" {} \;
-sudo find /data -type f -name "*.js" -exec sed -i "s/hyperswitch_client_url/$hyperswitch_client_url/g" {} \;
+sudo find /data -type f -name "*.js" -exec sed -i "s|backend_url|https://{{app_cloudfront_url}}|g" {} \;
+sudo find /data -type f -name "*.js" -exec sed -i "s|http://hyperswitch_client_url:9090|https://{{sdk_cloudfront_url}}|g" {} \;
 
 # folder structure the SDK and serve it using a simple http server
 cd /
@@ -34,24 +37,24 @@ cd /
 # Hyperswitch Demo APP [Frontend application]
 # Create a merchant and get the keys.
 # Required for the frontend application to communicate with the backend application
-export MERCHANT_ID=$(curl --silent --location --request POST 'http://{{private_router_host}}/user/signup' \
+export MERCHANT_ID=$(curl --silent --location --request POST 'https://{{app_cloudfront_url}}/user/signup' \
   --header 'Content-Type: application/json' \
   --data-raw '{
       "email": "itisatest@gmail.com",
       "password": "admin"
   }' | jq -r '.merchant_id')
 
-export HYPERSWITCH_PUBLISHABLE_KEY=$(curl --silent --location --request GET 'http://{{private_router_host}}/accounts/'$MERCHANT_ID \
+export HYPERSWITCH_PUBLISHABLE_KEY=$(curl --silent --location --request GET 'https://{{app_cloudfront_url}}/accounts/'$MERCHANT_ID \
   --header 'Accept: application/json' \
   --header 'api-key: '{{admin_api_key}} | jq -r '.publishable_key')
 
-export HYPERSWITCH_SECRET_KEY=$(curl --silent --location --request POST 'http://{{private_router_host}}/api_keys/'$MERCHANT_ID \
+export HYPERSWITCH_SECRET_KEY=$(curl --silent --location --request POST 'https://{{app_cloudfront_url}}/api_keys/'$MERCHANT_ID \
   --header 'Content-Type: application/json' \
   --header 'Accept: application/json' \
   --header 'api-key: '{{admin_api_key}} \
   --data-raw '{"name":"API Key 1","description":null,"expiration":"2038-01-19T03:14:08.000Z"}' | jq -r '.api_key')
 
-export CONNECTOR_KEY=$(curl --silent --location --request POST 'http://{{private_router_host}}/account/'$MERCHANT_ID'/connectors' \
+export CONNECTOR_KEY=$(curl --silent --location --request POST 'https://{{app_cloudfront_url}}/account/'$MERCHANT_ID'/connectors' \
   --header 'Content-Type: application/json' \
   --header 'Accept: application/json' \
   --header 'api-key: '{{admin_api_key}} \
@@ -63,9 +66,9 @@ MERCHANT_ID=$MERCHANT_ID
 HYPERSWITCH_PUBLISHABLE_KEY=$HYPERSWITCH_PUBLISHABLE_KEY
 HYPERSWITCH_SECRET_KEY=$HYPERSWITCH_SECRET_KEY
 CONNECTOR_KEY=$CONNECTOR_KEY
-HYPERSWITCH_SERVER_URL=http://$backend_url:80
-HYPERSWITCH_CLIENT_URL=http://$hyperswitch_client_url:9090/0.109.2/v1
+HYPERSWITCH_SERVER_URL=https://{{app_cloudfront_url}}
+HYPERSWITCH_CLIENT_URL=https://{{sdk_cloudfront_url}}/0.27.2/v0
 EOF
 
 docker pull juspaydotin/hyperswitch-web:v1.0.12
-docker run --env-file .env -p 5252:5252 juspaydotin/hyperswitch-web:v1.0.12
+docker run -d --env-file .env -p 5252:5252 juspaydotin/hyperswitch-web:v1.0.12

--- a/lib/aws/stack.ts
+++ b/lib/aws/stack.ts
@@ -1,5 +1,6 @@
 import * as cdk from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { Construct } from "constructs";
 import { Config, EC2Config} from "./config";
 import { Vpc, SubnetNames } from "./networking";
@@ -16,6 +17,9 @@ import * as iam from "aws-cdk-lib/aws-iam";
 import { DatabaseInstance } from "aws-cdk-lib/aws-rds";
 import { HyperswitchSDKStack } from "./hs-sdk";
 import { DistributionConstruct } from './distribution';
+import * as ssm from "aws-cdk-lib/aws-ssm";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
 
 export class AWSStack extends cdk.Stack {
   constructor(scope: Construct, config: Config) {
@@ -51,24 +55,144 @@ export class AWSStack extends cdk.Stack {
         config = update_hosts_standalone(config, rds.standaloneDb.instanceEndpoint.hostname, elasticache.cluster.attrRedisEndpointAddress);
       }
 
+      const ec2Sg = new ec2.SecurityGroup(this, 'EC2SecurityGroup', {
+        vpc: vpc.vpc,
+        description: 'Security group for EC2 instances',
+        allowAllOutbound: true
+      });
+
+      const appAlbSg = new ec2.SecurityGroup(this, 'AppAlbSg', {
+        vpc: vpc.vpc,
+        description: 'SG for App ALB',
+        allowAllOutbound: true,
+      });
+      appAlbSg.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(80));
+      appAlbSg.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(9000));
+
+      ec2Sg.addEgressRule(
+        ec2.Peer.anyIpv4(),
+        ec2.Port.tcp(443),
+        'Allow outbound HTTPS traffic for SSM'
+      );
+
+      const appAlb = new cdk.aws_elasticloadbalancingv2.ApplicationLoadBalancer(this, 'AppALB', {
+        vpc: vpc.vpc,
+        internetFacing: true,
+        securityGroup: appAlbSg,
+        vpcSubnets: { 
+          subnetType: ec2.SubnetType.PUBLIC,
+          onePerAz: true
+        },
+      });
+
+      const sdkAlbSg = new ec2.SecurityGroup(this, 'SdkAlbSg', {
+        vpc: vpc.vpc,
+        description: 'SG for SDK ALB',
+        allowAllOutbound: true,
+      });
+      sdkAlbSg.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(9090));
+      sdkAlbSg.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(5252));
+
+      const sdkAlb = new cdk.aws_elasticloadbalancingv2.ApplicationLoadBalancer(this, 'SdkALB', {
+        vpc: vpc.vpc,
+        internetFacing: true,
+        securityGroup: sdkAlbSg,
+        vpcSubnets: { 
+          subnetType: ec2.SubnetType.PUBLIC,
+          onePerAz: true
+        },
+      });
+
+      config.hyperswitch_ec2.app_alb_dns = appAlb.loadBalancerDnsName;
+      config.hyperswitch_ec2.sdk_alb_dns = sdkAlb.loadBalancerDnsName;
+
+      const appAlb80Distribution = new cloudfront.Distribution(this, 'StandaloneDistribution', {
+        defaultBehavior: {
+          origin: new origins.HttpOrigin(appAlb.loadBalancerDnsName, {
+            protocolPolicy: cloudfront.OriginProtocolPolicy.HTTP_ONLY,
+          }),
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.ALLOW_ALL,
+          originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER,
+          allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
+          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+        },
+      });
+      const appAlb9000Distribution = new cloudfront.Distribution(this, 'ControlCenterDistribution', {
+        defaultBehavior: {
+          origin: new origins.HttpOrigin(appAlb.loadBalancerDnsName, {
+            protocolPolicy: cloudfront.OriginProtocolPolicy.HTTP_ONLY,
+            httpPort: 9000,
+          }),
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.ALLOW_ALL,
+          originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER,
+          allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
+          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+        },
+      });
+      const sdkAlb9090Distribution = new cloudfront.Distribution(this, 'SdkAssetsDistribution', {
+        defaultBehavior: {
+          origin: new origins.HttpOrigin(sdkAlb.loadBalancerDnsName, {
+            protocolPolicy: cloudfront.OriginProtocolPolicy.HTTP_ONLY,
+            httpPort: 9090,
+          }),
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.ALLOW_ALL,
+          originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER,
+          allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
+          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+        },
+      });
+  
+      const appCloudFrontUrl = appAlb80Distribution.distributionDomainName;
+      const controlCenterCloudFrontUrl = appAlb9000Distribution.distributionDomainName;
+      const sdkCloudFrontUrl = sdkAlb9090Distribution.distributionDomainName;
+
+      const ec2Role = new iam.Role(this, 'HyperswitchEC2Role', {
+        assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
+        managedPolicies: [
+          iam.ManagedPolicy.fromAwsManagedPolicyName('CloudWatchAgentServerPolicy'),
+          iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMFullAccess')
+        ]
+      });
+
+      ec2Role.addToPolicy(new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'ssm:UpdateInstanceInformation',
+          'ssmmessages:CreateControlChannel',
+          'ssmmessages:CreateDataChannel',
+          'ssmmessages:OpenControlChannel',
+          'ssmmessages:OpenDataChannel',
+          'ec2messages:AcknowledgeMessage',
+          'ec2messages:DeleteMessage',
+          'ec2messages:FailMessage',
+          'ec2messages:GetEndpoint',
+          'ec2messages:GetMessages',
+          'ec2messages:SendReply'
+        ],
+        resources: ['*']
+      }));
+
       let hyperswitch_ec2 = new EC2Instance(
         this,
         vpc.vpc,
-        get_standalone_ec2_config(config),
+        {
+          ...get_standalone_ec2_config(config, appCloudFrontUrl, sdkCloudFrontUrl),
+          role: ec2Role
+        }
       );
-
+      
       rds.sg.addIngressRule(hyperswitch_ec2.sg, ec2.Port.tcp(5432));
       elasticache.sg.addIngressRule(hyperswitch_ec2.sg, ec2.Port.tcp(6379));
       hyperswitch_ec2.sg.addEgressRule(rds.sg, ec2.Port.tcp(5432));
       hyperswitch_ec2.sg.addEgressRule(elasticache.sg, ec2.Port.tcp(6379));
       hyperswitch_ec2.sg.addIngressRule(
         // To access the Router for User
-        ec2.Peer.ipv4("0.0.0.0/0"),
+        ec2.Peer.ipv4(vpc.vpc.vpcCidrBlock),
         ec2.Port.tcp(80),
       );
       hyperswitch_ec2.sg.addIngressRule(
         // To access the Control Center
-        ec2.Peer.ipv4("0.0.0.0/0"),
+        ec2.Peer.ipv4(vpc.vpc.vpcCidrBlock),
         ec2.Port.tcp(9000),
       );
       hyperswitch_ec2.sg.addIngressRule(
@@ -78,7 +202,7 @@ export class AWSStack extends cdk.Stack {
       );
       hyperswitch_ec2.sg.addIngressRule(
         // To SSH into the instance
-        ec2.Peer.ipv4("0.0.0.0/0"),
+        ec2.Peer.ipv4(vpc.vpc.vpcCidrBlock),
         ec2.Port.tcp(22),
       );
 
@@ -86,24 +210,26 @@ export class AWSStack extends cdk.Stack {
       let hyperswitch_sdk_ec2 = new EC2Instance(
         this,
         vpc.vpc,
-        get_standalone_sdk_ec2_config(config, hyperswitch_ec2),
-        hyperswitch_ec2.getInstance(),
+        {
+          ...get_standalone_sdk_ec2_config(config, appCloudFrontUrl, sdkCloudFrontUrl),
+          role: ec2Role
+        }
       );
 
       // create an security group for the SDK and add rules to access the router and demo app with port 1234 after the hyperswitch_sdk_ec2 is created
       hyperswitch_sdk_ec2.sg.addIngressRule(
         // To access the SDK
-        ec2.Peer.ipv4("0.0.0.0/0"),
+        ec2.Peer.ipv4(vpc.vpc.vpcCidrBlock),
         ec2.Port.tcp(9090),
       );
       hyperswitch_sdk_ec2.sg.addIngressRule(
         // To Access Demo APP
-        ec2.Peer.ipv4("0.0.0.0/0"),
+        ec2.Peer.ipv4(vpc.vpc.vpcCidrBlock),
         ec2.Port.tcp(5252),
       );
       hyperswitch_sdk_ec2.sg.addIngressRule(
         // To SSH into the instance
-        ec2.Peer.ipv4("0.0.0.0/0"),
+        ec2.Peer.ipv4(vpc.vpc.vpcCidrBlock),
         ec2.Port.tcp(22),
       );
 
@@ -118,30 +244,75 @@ export class AWSStack extends cdk.Stack {
         ec2.Port.tcp(80)
       );
 
+      new ec2.CfnSecurityGroupIngress(this, 'AppAlbIngress', {
+        groupId: hyperswitch_ec2.sg.securityGroupId,
+        ipProtocol: 'tcp',
+        fromPort: 80,
+        toPort: 80,
+        sourceSecurityGroupId: appAlbSg.securityGroupId,
+      });
+
+      new ec2.CfnSecurityGroupIngress(this, 'AppAlbIngress9000', {
+        groupId: hyperswitch_ec2.sg.securityGroupId,
+        ipProtocol: 'tcp',
+        fromPort: 9000,
+        toPort: 9000,
+        sourceSecurityGroupId: appAlbSg.securityGroupId,
+      });
+
+      const listener80 = appAlb.addListener('Listener80', { port: 80, protocol: elbv2.ApplicationProtocol.HTTP });
+      const target80 = new elbv2.ApplicationTargetGroup(this, 'AppTarget80', {
+        vpc: vpc.vpc,
+        port: 80,
+        protocol: elbv2.ApplicationProtocol.HTTP,
+        targetType: elbv2.TargetType.INSTANCE,
+        targets: [hyperswitch_ec2],
+        healthCheck: {
+          path: '/health',
+          protocol: elbv2.Protocol.HTTP,
+          unhealthyThresholdCount: 10,
+          healthyThresholdCount: 2,
+          timeout: cdk.Duration.seconds(30),
+          interval: cdk.Duration.seconds(60),
+          healthyHttpCodes: '200-499'
+        }
+      });
+      listener80.addTargetGroups('AppTargetGroup80', {
+        targetGroups: [target80]
+      });
+
+      const listener9000 = appAlb.addListener('Listener9000', { port: 9000, protocol: elbv2.ApplicationProtocol.HTTP });
+      listener9000.addTargets('AppTarget9000', {
+        port: 9000,
+        protocol: elbv2.ApplicationProtocol.HTTP,
+        targets: [hyperswitch_ec2],
+        healthCheck: { path: '/', protocol: elbv2.Protocol.HTTP }
+      });
+
+      const sdkListener9090 = sdkAlb.addListener('SdkListener9090', { port: 9090, protocol: elbv2.ApplicationProtocol.HTTP });
+      sdkListener9090.addTargets('SdkTarget9090', {
+        port: 9090,
+        protocol: elbv2.ApplicationProtocol.HTTP,
+        targets: [hyperswitch_sdk_ec2],
+        healthCheck: { path: '/', protocol: elbv2.Protocol.HTTP }
+      });
+
+      const sdkListener5252 = sdkAlb.addListener('SdkListener5252', { port: 5252, protocol: elbv2.ApplicationProtocol.HTTP });
+      sdkListener5252.addTargets('SdkTarget5252', {
+        port: 5252,
+        protocol: elbv2.ApplicationProtocol.HTTP,
+        targets: [hyperswitch_sdk_ec2],
+        healthCheck: { path: '/', protocol: elbv2.Protocol.HTTP }
+      });
+
       new cdk.CfnOutput(this, "StandaloneURL", {
-        value:
-          "http://" +
-          hyperswitch_ec2.getInstance().instancePublicIp +
-          "/health",
+        value: `https://${appAlb80Distribution.distributionDomainName}/health`,
       });
       new cdk.CfnOutput(this, "ControlCenterURL", {
-        value:
-          "http://" +
-          hyperswitch_ec2.getInstance().instancePublicIp +
-          ":9000" +
-          "\nFor login, use email id as 'itisatest@gmail.com' and password is admin",
+        value: `https://${appAlb9000Distribution.distributionDomainName}/`,
       });
       new cdk.CfnOutput(this, "SdkAssetsURL", {
-        value:
-          "http://" +
-          hyperswitch_sdk_ec2.getInstance().instancePublicIp +
-          ":9090",
-      });
-      new cdk.CfnOutput(this, "DemoApp", {
-        value:
-          "http://" +
-          hyperswitch_sdk_ec2.getInstance().instancePublicIp +
-          ":5252",
+        value: `https://${sdkAlb9090Distribution.distributionDomainName}/0.27.2/v0/HyperLoader.js`,
       });
     } else {
       const aws_arn = scope.node.tryGetContext("aws_arn");
@@ -168,18 +339,18 @@ export class AWSStack extends cdk.Stack {
         locker,
       );
 
-    const controlCenterHost = this.node.tryGetContext("control_center_host");
-    const appHost = this.node.tryGetContext("app_host");
+      const controlCenterHost = this.node.tryGetContext("control_center_host");
+      const appHost = this.node.tryGetContext("app_host");
 
-    if (controlCenterHost && appHost) {
-      const distribution = new DistributionConstruct(this, "CloudFrontDistributions", {
-        controlCenterHost,
-        appHost,
-      });
-      let hsSdk = new HyperswitchSDKStack(this, eks, distribution);
-    } else {
-      console.warn("Skipping DistributionConstruct creation as context values are missing in stack.ts");
-    }
+      if (controlCenterHost && appHost) {
+        const distribution = new DistributionConstruct(this, "CloudFrontDistributions", {
+          controlCenterHost,
+          appHost,
+        });
+        let hsSdk = new HyperswitchSDKStack(this, eks, distribution);
+      } else {
+        console.warn("Skipping DistributionConstruct creation as context values are missing in stack.ts");
+      }
     
       if (locker) locker.locker_ec2.addClient(eks.sg, ec2.Port.tcp(8080));
       rds.sg.addIngressRule(eks.sg, ec2.Port.tcp(5432));
@@ -355,14 +526,17 @@ function update_hosts_standalone(config: Config, db_host: string, redis_host: st
   return config;
 }
 
-function get_standalone_ec2_config(config: Config) {
+function get_standalone_ec2_config(config: Config, appCloudFrontUrl?: string, sdkCloudFrontUrl?: string) {
+  const appAlbDns = config.hyperswitch_ec2.app_alb_dns ?? "";
   let customData = readFileSync("lib/aws/userdata.sh", "utf8")
     .replaceAll("{{redis_host}}", config.hyperswitch_ec2.redis_host)
     .replaceAll("{{db_host}}", config.hyperswitch_ec2.db_host)
     .replaceAll("{{password}}", config.rds.password)
     .replaceAll("{{admin_api_key}}", config.hyperswitch_ec2.admin_api_key)
     .replaceAll("{{db_username}}", config.rds.db_user)
-    .replaceAll("{{db_name}}", config.rds.db_name);
+    .replaceAll("{{db_name}}", config.rds.db_name)
+    .replaceAll("{{app_cloudfront_url}}", appCloudFrontUrl || "")
+    .replaceAll("{{sdk_cloudfront_url}}", sdkCloudFrontUrl || "");
   let ec2_config: EC2Config = {
     id: "hyperswitch_standalone_app_cc_ec2",
     instanceType: ec2.InstanceType.of(
@@ -372,24 +546,18 @@ function get_standalone_ec2_config(config: Config) {
     machineImage: new ec2.AmazonLinuxImage(),
     vpcSubnets: { subnetGroupName: SubnetNames.PublicSubnet },
     userData: ec2.UserData.custom(customData),
-    allowOutboundTraffic: true,
+    allowOutboundTraffic: true
   };
   return ec2_config;
 }
 
-function get_standalone_sdk_ec2_config(
-  config: Config,
-  hyperswitch_ec2: EC2Instance,
-) {
+function get_standalone_sdk_ec2_config(config: Config, appCloudFrontUrl?: string, sdkCloudFrontUrl?: string) {
   let customData = readFileSync("lib/aws/sdk_userdata.sh", "utf8")
-    .replaceAll(
-      "{{router_host}}",
-      hyperswitch_ec2.getInstance().instancePublicIp,
-    )
-    .replaceAll("{{private_router_host}}", hyperswitch_ec2.getInstance().instancePrivateIp)
     .replaceAll("{{admin_api_key}}", config.hyperswitch_ec2.admin_api_key)
-    .replaceAll("{{version}}", "0.109.2")
-    .replaceAll("{{sub_version}}", "v0");
+    .replaceAll("{{version}}", "0.27.2")
+    .replaceAll("{{sub_version}}", "v0")
+    .replaceAll("{{app_cloudfront_url}}", appCloudFrontUrl || "")
+    .replaceAll("{{sdk_cloudfront_url}}", sdkCloudFrontUrl || "");
   let ec2_config: EC2Config = {
     id: "hyperswitch_standalone_sdk_demo_ec2",
     instanceType: ec2.InstanceType.of(

--- a/lib/aws/userdata.sh
+++ b/lib/aws/userdata.sh
@@ -5,6 +5,9 @@ sudo yum install docker -y
 sudo service docker start
 sudo usermod -a -G docker ec2-user
 newgrp docker
+sudo yum install -y amazon-ssm-agent
+systemctl enable amazon-ssm-agent
+systemctl start amazon-ssm-agent
 
 # Installing Hyperswitch Router application [Backend application]
 
@@ -27,7 +30,7 @@ ROUTER__ANALYTICS__SQLX__PASSWORD={{password}}
 ROUTER__ANALYTICS__SQLX__DBNAME={{db_name}}
 ROUTER__LOCKER__MOCK_LOCKER=true
 ROUTER__SERVER__HOST=0.0.0.0
-ROUTER__SERVER__BASE_URL=$(curl ifconfig.me)
+ROUTER__SERVER__BASE_URL=https://{{app_cloudfront_url}}
 ROUTER__SECRETS__ADMIN_API_KEY={{admin_api_key}}
 EOF
 
@@ -41,8 +44,8 @@ docker run -d --env-file .env -p 80:8080 -v `pwd`/:/local/config juspaydotin/hyp
 docker pull juspaydotin/hyperswitch-control-center:v1.29.9
 
 cat << EOF >> .env
-apiBaseUrl=http://$(curl ifconfig.me):80
-sdkBaseUrl=http://$(curl ifconfig.me):80
+apiBaseUrl=https://{{app_cloudfront_url}}
+sdkBaseUrl=https://{{sdk_cloudfront_url}}/0.27.2/v0/HyperLoader.js
 EOF
 
 docker run -d --env-file .env -p 9000:9000 juspaydotin/hyperswitch-control-center:v1.29.9


### PR DESCRIPTION
**Free Tier Setup & Deployment**

- CloudFront Distributions: Added for App, SDK, and Control Center to improve resource delivery and security.
- Application Load Balancers (ALB): Separate ALBs for App and SDK with improved security group rules (now VPC-restricted).
- User Data Scripts: Updated to use new CloudFront URLs, enable SSM Agent by default, and set environment variables for App/SDK.
- Stack Outputs: Now provide HTTPS CloudFront URLs for health checks, control center, SDK assets, and demo app.
- Upgrade Script: All API calls and Helm deploys now use HTTPS and CloudFront.


**Infrastructure & Dependencies**

- AWS CDK Upgrade: Migrated from CDK v1 to v2 libraries for future compatibility.
- Docker Images: Updated to latest versions for router, producer, consumer, control center, web, metrics-server, Istio, etc.
- Networking: Switched to ec2.IpAddresses.cidr for modern VPC setup.

**Kubernetes / Helm**

- Kubernetes & Istio: Upgraded versions (K8s 1.32, Istio 1.25.0).
- Helm Chart: New repo URL and chart version; improved deployment order and dependencies.
- Config & Secrets: Expanded support for new key types (paze, google pay, etc.).

