### PR TITLE
fix: only install CDK if required and fix show_loader

### DIFF
--- a/bash/deps.sh
+++ b/bash/deps.sh
@@ -20,16 +20,17 @@ if [ "$version" -lt 18 ]; then
 fi
 echo "Node.js version is valid."
 
-# Install AWS CDK
-echo "Installing AWS CDK..."
-npm install -g aws-cdk &
-show_loader "Installing AWS CDK..."
-echo "AWS CDK is installed successfully."
-
-# Check for AWS CDK
 if ! command -v cdk &>/dev/null; then
-    echo "AWS CDK could not be found. Please rerun 'bash install.sh' with Sudo access and ensure the command is available within the \$PATH"
-    exit 1
+    # Install AWS CDK
+    echo "Installing AWS CDK..."
+    npm install -g aws-cdk &
+    show_loader "Installing AWS CDK..."
+    echo "AWS CDK is installed successfully."
+
+    if ! command -v cdk &>/dev/null; then
+        echo "AWS CDK could not be found. Please rerun 'bash install.sh' with Sudo access and ensure the command is available within the \$PATH"
+        exit 1
+    fi
 fi
 
 # Determine OS and run respective dependency script

--- a/bash/utils.sh
+++ b/bash/utils.sh
@@ -6,7 +6,7 @@ show_loader() {
     local pid=$!
     local delay=0.3
     local spinstr='|/-\\'
-    while [ "$(ps a | awk '{print $1}' | grep $pid)" ]; do
+    while [[ ! -z $pid && "$(ps a | awk '{print $1}' | grep $pid)" ]]; do
         local temp=${spinstr#?}
         printf "\r%s [%c]  " "$message" "$spinstr"
         local spinstr=$temp${spinstr%"$temp"}


### PR DESCRIPTION
\#### Summary
This commit makes two minor shell utility related improvements:
* Update `deps.sh` to only install AWS CDK if not already present
* Fix `show_loader()` function's `while` conditional to handle empty
  `$pid`` edge case

\#### Testing
Tested this by running the installer multiple times with and without CDK
installed.

---

Signed-Off-By: Willem Barkhuizen (<willem.barkhuizen@sanlam.co.za>)
