### PR TITLE
fix: implement dynamic version fetching for Loki stack components

### DIFF
--- a/dependencies/code_builder/buildspec.yml
+++ b/dependencies/code_builder/buildspec.yml
@@ -1,6 +1,28 @@
 version: 0.2
 
 phases:
+  pre_build:
+    commands:
+      - echo "Installing Helm..."
+      - curl -fsSL https://get.helm.sh/helm-v3.12.0-linux-amd64.tar.gz | tar xz
+      - mv linux-amd64/helm /usr/local/bin/
+      - helm version
+      - |
+        echo "Fetching loki-stack chart to extract compatible versions..."
+        helm repo add grafana https://grafana.github.io/helm-charts
+        helm repo update
+        LATEST_VERSION=$(helm search repo grafana/loki-stack -o json | jq -r '.[0].version')
+        echo "Using loki-stack chart version: $LATEST_VERSION"
+        helm pull grafana/loki-stack --version $LATEST_VERSION --untar
+        cd loki-stack
+        LOKI_TAG=$(cat ./charts/loki/Chart.yaml | grep "^appVersion:" | awk '{print $2}' | tr -d '"')
+        PROMTAIL_TAG=$(cat ./charts/promtail/Chart.yaml | grep "^appVersion:" | awk '{print $2}' | tr -d '"')
+        GRAFANA_TAG=$(cat ./charts/grafana/Chart.yaml | grep "^appVersion:" | awk '{print $2}' | tr -d '"')
+        cd ..
+        export LOKI_TAG=${LOKI_TAG:-latest}
+        export PROMTAIL_TAG=${PROMTAIL_TAG:-latest}
+        export GRAFANA_TAG=${GRAFANA_TAG:-latest}
+
   build:
     commands:
        - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin https://$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
@@ -48,6 +70,18 @@ phases:
               docker pull "$IMAGE:1.25.0" && \
               docker tag "$IMAGE:1.25.0" "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE:1.25.0"
               docker push "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE:1.25.0"
+          elif [[ $IMAGE == "grafana/grafana" ]]; then
+              docker pull "$IMAGE:${GRAFANA_TAG}" && \
+              docker tag "$IMAGE:${GRAFANA_TAG}" "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE:${GRAFANA_TAG}" && \
+              docker push "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE:${GRAFANA_TAG}"
+          elif [[ $IMAGE == "grafana/loki" ]]; then
+              docker pull "$IMAGE:${LOKI_TAG}" && \
+              docker tag "$IMAGE:${LOKI_TAG}" "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE:${LOKI_TAG}" && \
+              docker push "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE:${LOKI_TAG}"
+          elif [[ $IMAGE == "grafana/promtail" ]]; then
+              docker pull "$IMAGE:${PROMTAIL_TAG}" && \
+              docker tag "$IMAGE:${PROMTAIL_TAG}" "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE:${PROMTAIL_TAG}" && \
+              docker push "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE:${PROMTAIL_TAG}"
           elif [[ $IMAGE == "kiwigrid/k8s-sidecar" ]]; then
               docker pull "$IMAGE:1.30.3" && \
               docker tag "$IMAGE:1.30.3" "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE:1.30.3"
@@ -98,4 +132,3 @@ phases:
             docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE:v0.5.1
           fi
         done
-

--- a/lib/aws/eks.ts
+++ b/lib/aws/eks.ts
@@ -1139,8 +1139,7 @@ export class EksStack {
             imageRegisrty: `${privateEcrRepository}`,
           },
           image: {
-            repository: `${privateEcrRepository}/grafana/grafana`,
-            tag: "latest",
+            repository: `${privateEcrRepository}/grafana/grafana`
           },
           sidecar: {
             image: {
@@ -1149,7 +1148,18 @@ export class EksStack {
               sha: ""
             },
             imagePullPolicy: "IfNotPresent",
-            resources: {}
+            resources: {},
+            env: {
+              SKIP_TLS_VERIFY: "true",
+              LOG_LEVEL: "info",
+              REQ_RETRY_TOTAL: "10",
+              REQ_RETRY_CONNECT: "10",
+              REQ_RETRY_READ: "10",
+              REQ_RETRY_BACKOFF_FACTOR: "1.0",
+              REQ_TIMEOUT: "30",
+              SLEEP_TIME: "60"
+            },
+            sleepBeforeStart: 30
           },
           enabled: true,
           adminPassword: "admin",
@@ -1272,7 +1282,6 @@ export class EksStack {
           },
           image: {
             repository: `${privateEcrRepository}/grafana/loki`,
-            tag: "latest",
           },
         },
         promtail: {
@@ -1283,7 +1292,6 @@ export class EksStack {
           image: {
             registry: `${privateEcrRepository}`,
             repository: "grafana/promtail",
-            tag: "latest"
           },
           config: {
             snippets: {
@@ -1488,7 +1496,7 @@ class DockerImagesToEcr {
       statements: [
         new iam.PolicyStatement({
           actions: [
-            "codebuild:StartBuild",
+            "codebuild:StartBuild", 
           ],
           resources: [this.codebuildProject.projectArn],
         }),

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -20,7 +20,7 @@ ADMIN_API_KEY=$1
 CARD_VAULT=$2
 APP_PROXY_SETUP=$3
 KEYMANAGER_ENABLED=$4
-LOGS_HOST=$(kubectl get ingress hyperswitch-grafana-logs-alb-ingress -n hyperswitch -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+LOGS_HOST=$(kubectl get ingress loki-grafana -n loki -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 INGRESS_CONTROL_CENTER_HOST=$(kubectl get ingress hyperswitch-control-center-ingress -n hyperswitch -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 CONTROL_CENTER_HOST=$(aws cloudfront list-distributions --query "DistributionList.Items[?Origins.Items[?DomainName=='${INGRESS_CONTROL_CENTER_HOST}']].DomainName" --output text);
 #SDK_HOST=$(kubectl get ingress hyperswitch-sdk-demo-ingress -n hyperswitch -o jsonpath='{.status.loadBalancer.ingress[0].hostname}') #sdk-demo-ingress NOT FOUND
@@ -162,7 +162,7 @@ echoLog "$bold Service                           Host$reset"
 echoLog "--------------------------------------------------------------------------------"
 echoLog "$green HyperloaderJS Hosted at           $blue$HYPERLOADER$reset"
 echoLog "$green App server running on             $blue"https://$APP_HOST/health"$reset"
-echoLog "$green Logs server running on            $blue"https://$LOGS_HOST"$reset, Login with $yellow username: admin, password: admin$reset , Please change on startup"
+echoLog "$green Logs server running on            $blue"http://$LOGS_HOST"$reset, Login with $yellow username: admin, password: admin$reset , Please change on startup"
 echoLog "$green Control center server running on  $blue"https://$CONTROL_CENTER_HOST"$reset, Login with $yellow Email: test@gmail.com, password: admin$reset , Please change on startup"
 #echoLog "$green Hyperswitch Demo Store running on $blue"https://$SDK_HOST"$reset"
 echoLog "--------------------------------------------------------------------------------"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -20,7 +20,7 @@ ADMIN_API_KEY=$1
 CARD_VAULT=$2
 APP_PROXY_SETUP=$3
 KEYMANAGER_ENABLED=$4
-LOGS_HOST=$(kubectl get ingress hyperswitch-logs-alb-ingress -n hyperswitch -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+LOGS_HOST=$(kubectl get ingress hyperswitch-grafana-logs-alb-ingress -n hyperswitch -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 INGRESS_CONTROL_CENTER_HOST=$(kubectl get ingress hyperswitch-control-center-ingress -n hyperswitch -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 CONTROL_CENTER_HOST=$(aws cloudfront list-distributions --query "DistributionList.Items[?Origins.Items[?DomainName=='${INGRESS_CONTROL_CENTER_HOST}']].DomainName" --output text);
 #SDK_HOST=$(kubectl get ingress hyperswitch-sdk-demo-ingress -n hyperswitch -o jsonpath='{.status.loadBalancer.ingress[0].hostname}') #sdk-demo-ingress NOT FOUND


### PR DESCRIPTION
## Description

This PR enhances the Grafana stack deployment by implementing dynamic version management for Loki, Promtail, and Grafana components. Instead of using hardcoded "latest" tags, the build process now fetches compatible versions directly from the official Helm charts.

### Changes Made

#### 1. Dynamic Version Management (`dependencies/code_builder/buildspec.yml`)
- Added a `pre_build` phase that:
  - Installs Helm v3.12.0
  - Fetches the latest loki-stack chart from Grafana's Helm repository
  - Extracts compatible versions for Loki, Promtail, and Grafana from their respective Chart.yaml files
  - Exports these versions as environment variables for use in the build phase

#### 2. Enhanced Sidecar Configuration (`lib/aws/eks.ts`)
- Removed hardcoded "latest" tags from Grafana, Loki, and Promtail image configurations
- Added comprehensive environment variables for the k8s-sidecar container:
  - `SKIP_TLS_VERIFY`: Set to "true" for internal communications
  - `LOG_LEVEL`: Set to "info" for better debugging
  - Retry configurations: `REQ_RETRY_TOTAL`, `REQ_RETRY_CONNECT`, `REQ_RETRY_READ` (all set to 10)
  - `REQ_RETRY_BACKOFF_FACTOR`: Set to 1.0
  - `REQ_TIMEOUT`: Set to 30 seconds
  - `SLEEP_TIME`: Set to 60 seconds
- Added `sleepBeforeStart: 30` to allow services to initialize properly

#### 3. Bug Fix (`upgrade.sh`)
- Fixed incorrect ingress name from `hyperswitch-logs-alb-ingress -n hyperswitch` to `loki-grafana -n loki`
