### PR TITLE
chore : Update Helm chart references, certificate naming for encryption service

### DIFF
--- a/awsconfig.ts
+++ b/awsconfig.ts
@@ -12,7 +12,7 @@ export class Configuration {
     let tls_key_exists = existsSync("./rsa_sha256_key.pem");
     let tls_cert_exists = existsSync("./rsa_sha256_cert.pem");
     let ca_cert_exists = existsSync("./ca_cert.pem");
-    let client_cert_exists = existsSync("./client.pem");
+    let client_cert_exists = existsSync("./client_hyperswitch.pem");
     let config: Config = {
       stack: {
         name: "hyperswitch",
@@ -38,7 +38,7 @@ export class Configuration {
         tls_key: tls_key_exists ? readFileSync("./rsa_sha256_key.pem").toString() : "", 
         tls_cert: tls_cert_exists ? readFileSync("./rsa_sha256_cert.pem").toString() : "", 
         ca_cert: ca_cert_exists ? readFileSync("./ca_cert.pem").toString() : "",
-        client_cert: client_cert_exists ? readFileSync("./client.pem").toString() : "",
+        client_cert: client_cert_exists ? readFileSync("./client_hyperswitch.pem").toString() : "",
         access_token: scope.node.tryGetContext('keymanager_access_token') || "secret123",
         hash_context: scope.node.tryGetContext('keymanager_hash_context') || "keymanager:hyperswitch",
       },

--- a/lib/aws/eks.ts
+++ b/lib/aws/eks.ts
@@ -564,12 +564,6 @@ export class EksStack {
     });
     albControllerChart.node.addDependency(albControllerServiceAccount);
 
-    // Create Helm Installer Service Account with CRD permissions
-    const helmInstallerServiceAccount = cluster.addServiceAccount("HelmInstallerSA", {
-      name: "helm-installer",
-      namespace: "kube-system",
-    });
-
     cluster.openIdConnectProvider.openIdConnectProviderIssuer;
 
     nodegroupRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonEBSCSIDriverPolicy'));
@@ -932,7 +926,7 @@ export class EksStack {
           },
         },
         "hyperswitch-web": {
-          enabled: false,
+          enabled: true,
           services: {
             router: {
               host: "http://localhost:8080"
@@ -985,7 +979,7 @@ export class EksStack {
     });
 
     this.sdkBucket = sdkBucket;
-    hypersChart.node.addDependency(albControllerChart, triggerKMSEncryption, helmInstallerClusterRoleBinding);
+    hypersChart.node.addDependency(albControllerChart, triggerKMSEncryption); 
 
     if (appProxyEnabled) {
       const istioResources = new IstioResources(scope, 'IstioResources', {

--- a/lib/aws/eks.ts
+++ b/lib/aws/eks.ts
@@ -570,56 +570,6 @@ export class EksStack {
       namespace: "kube-system",
     });
 
-    // Create ClusterRole for CRD management
-    const helmInstallerClusterRole = cluster.addManifest("HelmInstallerClusterRole", {
-      apiVersion: "rbac.authorization.k8s.io/v1",
-      kind: "ClusterRole",
-      metadata: {
-        name: "helm-installer-role",
-      },
-      rules: [
-        {
-          apiGroups: ["apiextensions.k8s.io"],
-          resources: ["customresourcedefinitions"],
-          verbs: ["create", "get", "list", "watch", "update", "patch", "delete"],
-        },
-        {
-          apiGroups: ["*"],
-          resources: ["*"],
-          verbs: ["*"],
-        },
-        {
-          apiGroups: [""],
-          resources: ["namespaces"],
-          verbs: ["create", "get", "list", "watch", "update", "patch", "delete"],
-        },
-      ],
-    });
-
-    // Create ClusterRoleBinding
-    const helmInstallerClusterRoleBinding = cluster.addManifest("HelmInstallerClusterRoleBinding", {
-      apiVersion: "rbac.authorization.k8s.io/v1",
-      kind: "ClusterRoleBinding",
-      metadata: {
-        name: "helm-installer-role-binding",
-      },
-      roleRef: {
-        apiGroup: "rbac.authorization.k8s.io",
-        kind: "ClusterRole",
-        name: "helm-installer-role",
-      },
-      subjects: [
-        {
-          kind: "ServiceAccount",
-          name: "helm-installer",
-          namespace: "kube-system",
-        },
-      ],
-    });
-
-    helmInstallerClusterRoleBinding.node.addDependency(helmInstallerClusterRole);
-    helmInstallerClusterRoleBinding.node.addDependency(helmInstallerServiceAccount);
-
     cluster.openIdConnectProvider.openIdConnectProviderIssuer;
 
     nodegroupRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonEBSCSIDriverPolicy'));

--- a/lib/aws/istio_stack.ts
+++ b/lib/aws/istio_stack.ts
@@ -170,7 +170,7 @@ export class IstioResources extends Construct {
       wait: true,
     });
     this.trafficControlChart = trafficControlChart; 
-    this.trafficControlChart.node.addDependency(gateway,istiod); 
+    this.trafficControlChart.node.addDependency(gateway); 
 
     // Create a Lambda function to find the Istio ALB DNS name
     const albLookupFunction = new lambda.Function(this, 'GetIstioAlbDnsFunction', {

--- a/lib/aws/istio_stack.ts
+++ b/lib/aws/istio_stack.ts
@@ -119,7 +119,8 @@ export class IstioResources extends Construct {
 
     const trafficControlChart = cluster.addHelmChart('TrafficControlChart', {
       chart: 'hyperswitch-istio',
-      repository: 'https://juspay.github.io/hyperswitch-helm/charts/incubator/hyperswitch-istio',
+      repository: 'https://juspay.github.io/hyperswitch-helm/',
+      version: '0.1.1',
       release: 'hs-istio', 
       namespace: 'istio-system', 
       values: {
@@ -169,7 +170,7 @@ export class IstioResources extends Construct {
       wait: true,
     });
     this.trafficControlChart = trafficControlChart; 
-    this.trafficControlChart.node.addDependency(gateway); 
+    this.trafficControlChart.node.addDependency(gateway,istiod); 
 
     // Create a Lambda function to find the Istio ALB DNS name
     const albLookupFunction = new lambda.Function(this, 'GetIstioAlbDnsFunction', {

--- a/lib/aws/keymanager/stack.ts
+++ b/lib/aws/keymanager/stack.ts
@@ -177,7 +177,8 @@ export class Keymanager extends Construct {
         const kmsSecrets = new KmsSecrets(scope, triggerKMSEncryption);
         const keymanagerChart = cluster.addHelmChart("KeymanagerService", {
             chart: "hyperswitch-keymanager",
-            repository: "https://juspay.github.io/hyperswitch-helm/charts/incubator/hyperswitch-keymanager",
+            repository: "https://juspay.github.io/hyperswitch-helm/",
+            version: "0.1.1",
             namespace: "keymanager",
             release: "hs-keymanager",
             createNamespace: true,
@@ -186,7 +187,7 @@ export class Keymanager extends Construct {
             values: {
                 backend: "aws",
                 server: {
-                    image: "docker.juspay.io/juspaydotin/hyperswitch-encryption-service:v0.1.8",
+                    image: "docker.juspay.io/juspaydotin/hyperswitch-encryption-service:v0.1.10",
                     annotations: {
                         "eks.amazonaws.com/role-arn": kms_role.roleArn,
                     },


### PR DESCRIPTION
**Description:**
This PR introduces chores updates for chart references to the `Hyperswitch CDK` stack:

### **Changes Made**

* **Helm Chart Repository Updates**

  * Updated Helm chart repositories for Istio, Keymanager, and related components to use the latest root `hyperswitch-helm/` path instead of nested `/charts/incubator/...`.
  * Bumped `hyperswitch-encryption-service` image version from `v0.1.8` to `v0.1.10`.

* **Certificate Reference Fixes**

  * Updated `client_cert` file reference from `client.pem` to `client_hyperswitch.pem` in `awsconfig.ts`.

### **Impact**

* Aligns Helm repository paths with updated hosting structure.
* Updates certificate references for correct usage in Keymanager integration.
* Improves deployment reliability for new environments.

