### PR TITLE
feat(aws-eks): improved the error handling for fetch operations

### DIFF
--- a/lib/aws/eks.ts
+++ b/lib/aws/eks.ts
@@ -34,6 +34,16 @@ import { IstioResources } from './istio_stack';
 import { SecurityGroups } from './security_groups';
 // import { LockerSetup } from "./card-vault/components";
 
+interface AWSlbControllerIAMPolicyJSON {
+  Version: string;
+  Statement: Array<{
+    Effect: string;
+    Action: string | string[];
+    Resource: string | string[];
+    Condition?: Record<string, unknown>;
+  }>;
+}
+
 export class EksStack {
   sg: ec2.ISecurityGroup;
   hyperswitchHost: string;
@@ -223,15 +233,82 @@ export class EksStack {
       );
     }
 
+    const isAWSlbControllerIAMPolicyJSON = (object: unknown): object is AWSlbControllerIAMPolicyJSON => {
+      if (typeof object !== "object" || object === null) return false;
+      const candidate = object as Record<string, unknown>;
+      if (typeof candidate.Version !== "string" || !Array.isArray(candidate.Statement)) {
+        return false;
+      }
+      for (const statement of candidate.Statement) {
+        if (typeof statement !== "object" || statement === null) return false;
+        const s = statement as Record<string, unknown>;
+        if (typeof s.Effect !== "string") return false;
+        const action = s.Action;
+        if (typeof action === "string") {
+          // valid
+        } else if (Array.isArray(action)) {
+          if (!action.every(a => typeof a === "string")) return false;
+        } else {
+          return false;
+        }
+        const resource = s.Resource;
+        if (typeof resource === "string") {
+          // valid
+        } else if (Array.isArray(resource)) {
+          if (!resource.every(r => typeof r === "string")) return false;
+        } else {
+          return false;
+        }
+        if ("Condition" in s && (typeof s.Condition !== "object" || s.Condition === null)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
     const fetchAndCreatePolicy = async (
       url: string,
     ): Promise<iam.PolicyDocument> => {
       try {
         const response = await fetch(url);
-        const policyJSON = await response.json();
-        return iam.PolicyDocument.fromJson(policyJSON);
-      } catch (error) {
-        console.error("Error fetching or creating policy document:", error);
+        if (!response.ok) {
+          throw new Error(
+            `Failed to fetch IAM policy from \`${url}\`. ` +
+            `HTTP ${response.status} (${response.statusText}).`,
+          );
+        }
+        let policyJSON: unknown
+        try {
+          policyJSON = await response.json();
+        } catch (parseError: unknown) {
+          const parseErrorMessage = (
+            (parseError instanceof Error)
+              ? parseError.message
+              : String(parseError ?? "Unknown Error")
+          );
+          throw new Error(
+            `Failed to parse JSON response from \`${url}\`: ${parseErrorMessage}.`,
+          );
+        }
+        if (!isAWSlbControllerIAMPolicyJSON(policyJSON)) {
+          throw new Error(
+            `JSON from \`${url}\` does not match AWS IAM policy structure.`,
+          );
+        }
+        try {
+          return iam.PolicyDocument.fromJson(policyJSON);
+        } catch (policyError: unknown) {
+            const policyErrorMessage = (
+              (policyError instanceof Error)
+                ? policyError.message
+                : String(policyError ?? "Unknown Error")
+            );
+            throw new Error(
+              `Failed to create IAM policy from \`${url}\`: ${policyErrorMessage}.`,
+            );
+        }
+      } catch (error: unknown) {
+        console.error(`Failed to fetch and create IAM policy from \`${url}\`: `, error);
         throw error;
       }
     };
@@ -265,7 +342,7 @@ export class EksStack {
         console.error("Error fetching or creating ALB controller policy document:", error);
       });
 
-      const albControllerServiceAccount = cluster.addServiceAccount("ALBControllerSA", {
+    const albControllerServiceAccount = cluster.addServiceAccount("ALBControllerSA", {
       name: albControllerServiceAccountName,
       namespace: albControllerNamespace,
       annotations: {

--- a/lib/aws/eks.ts
+++ b/lib/aws/eks.ts
@@ -2,7 +2,7 @@ import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as cdk from "aws-cdk-lib";
 import * as eks from "aws-cdk-lib/aws-eks";
 import { KubectlV32Layer } from '@aws-cdk/lambda-layer-kubectl-v32';
-import * as cp from 'child_process'; 
+import * as cp from 'child_process';
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as iam from "aws-cdk-lib/aws-iam";
 import { Construct } from "constructs";
@@ -254,7 +254,7 @@ export class EksStack {
         "sts:AssumeRoleWithWebIdentity"
       ),
     });
-    
+
     fetchAndCreatePolicy(lbControllerPolicyUrl)
       .then((policy) => {
         albControllerRole.attachInlinePolicy(
@@ -536,7 +536,7 @@ export class EksStack {
     this.sg = cluster.clusterSecurityGroup;
 
     const appProxyEnabled = scope.node.tryGetContext('app_proxy_enabled') === 'true';
-    
+
     securityGroups.addEksClusterRules(securityGroups.clusterSecurityGroup, appProxyEnabled);
     securityGroups.addEksClusterRules(cluster.clusterSecurityGroup, appProxyEnabled);
 
@@ -651,7 +651,7 @@ export class EksStack {
 
     const oai = new cloudfront.OriginAccessIdentity(scope, 'SdkOAI');
     sdkBucket.grantRead(oai);
- 
+
     this.sdkDistribution = new cloudfront.CloudFrontWebDistribution(scope, 'sdkDistribution', {
       viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.ALLOW_ALL,
       originConfigs: [
@@ -664,7 +664,7 @@ export class EksStack {
         }
       ]
     });
-    
+
     this.sdkDistribution.node.addDependency(sdkBucket);
     new cdk.CfnOutput(scope, 'SdkDistribution', {
       value: this.sdkDistribution.distributionDomainName,
@@ -810,7 +810,7 @@ export class EksStack {
               locker_public_key: locker ? locker.locker_ec2.locker_pair.public_key : "locker-key",
               hyperswitch_private_key: locker ? locker.locker_ec2.tenant.private_key : "locker-key",
             },
-            basilisk: { 
+            basilisk: {
               host: "basilisk-host",
             },
             run_env: "sandbox",
@@ -987,7 +987,7 @@ export class EksStack {
     });
 
     this.sdkBucket = sdkBucket;
-    hypersChart.node.addDependency(albControllerChart, triggerKMSEncryption); 
+    hypersChart.node.addDependency(albControllerChart, triggerKMSEncryption);
 
     if (appProxyEnabled) {
       const istioResources = new IstioResources(scope, 'IstioResources', {
@@ -999,7 +999,7 @@ export class EksStack {
 
       const envoyAmiId = scope.node.tryGetContext('envoy_ami');
       const squidAmiId = scope.node.tryGetContext('squid_ami');
-      
+
       if (envoyAmiId || squidAmiId) {
         // Create AppProxiesConstruct with centralized security groups
         const appProxiesConstruct = new AppProxiesConstruct(scope, 'AppProxies', {
@@ -1013,7 +1013,7 @@ export class EksStack {
         });
 
         appProxiesConstruct.node.addDependency(istioResources);
-        
+
       }
     }
 
@@ -1318,7 +1318,7 @@ export class EksStack {
 
 
     lokiChart.node.addDependency(hypersChart);
-    
+
     this.lokiChart = lokiChart;
 
     cluster.addHelmChart("MetricsServer", {
@@ -1516,7 +1516,7 @@ class DockerImagesToEcr {
       statements: [
         new iam.PolicyStatement({
           actions: [
-            "codebuild:StartBuild", 
+            "codebuild:StartBuild",
           ],
           resources: [this.codebuildProject.projectArn],
         }),


### PR DESCRIPTION
i have handled the following error which can occur

1. network error which can occur during the fetch operation
2. parse error which can occur during the `reponse.json()`
3. handle the invalid AWS IAM policy format
4. policy error which can occur during conversion from json

fixes: #225 

i am happy to get feedback's for the changes i have made.
whether i am missed to handle any of the exceptions
or any further improvements is required.